### PR TITLE
fix(core): call spacing_units() in unhandled-units warning

### DIFF
--- a/src/python/clara-viz-core/clara/viz/core/datadefinition.py
+++ b/src/python/clara-viz-core/clara/viz/core/datadefinition.py
@@ -245,7 +245,7 @@ class DataDefinition():
                     if (self._img.spacing_units()[0] == "micrometer"):
                         downsamples /= 1000
                     else:
-                        print(f"Unhandled spacing units {self._img.spacing_units[0]}, using millimeter")
+                        print(f"Unhandled spacing units {self._img.spacing_units()[0]}, using millimeter")
 
                 # scale spacing (exclude color dimension)
                 for index in range(self._img.ndim - 1):


### PR DESCRIPTION
## Summary

When loading an image via cuCIM (version > 22.07) whose spacing units are not "micrometer", `DataDefinition.Array._parse_cucim()` is supposed to print a warning and fall back to millimeter. Instead it crashes with `TypeError: 'method' object is not subscriptable`, aborting the whole data load.

## Root cause

```python
if (self._img.spacing_units()[0] == "micrometer"):
    downsamples /= 1000
else:
    print(f"Unhandled spacing units {self._img.spacing_units[0]}, using millimeter")
```

The fallback path subscripts `self._img.spacing_units` (a bound method) instead of calling it. Everywhere else in the same function it is correctly invoked as `self._img.spacing_units()`.

## Fix

Call the method: `self._img.spacing_units()[0]`.

## Testing

No test suite exists in the repo for this Python package. Verified with a standalone script that loads `datadefinition.py` with mocked `cucim`/`CuImage` (spacing units "millimeter", cucim 22.08) and calls `_parse_cucim()`:

- With the fix: warning "Unhandled spacing units millimeter, using millimeter" is printed and parsing succeeds (PASS).
- With the fix stashed (unmodified code): same script fails at line 248 with `TypeError: 'method' object is not subscriptable`.

Commands run in an ephemeral env: `uv run --with numpy --with packaging python test_spacing_units.py`.

## Why existing tests missed it

The repo has no Python unit tests; the buggy line only executes on the non-micrometer fallback path with cuCIM > 22.07.